### PR TITLE
Phase 2 — perf: explicit image dimensions + lazy-load below-the-fold images

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
 <!-- HEADER -->
 <header class="site-header" id="header">
-    <a href="#hero"><img class="header-logo" src="./assets/img/bpmspace_weblogo.png" alt="BPMspace"></a>
+    <a href="#hero"><img class="header-logo" src="./assets/img/bpmspace_weblogo.png" alt="BPMspace" width="72" height="72"></a>
     <button class="mobile-menu-btn" aria-label="Menu"><svg class="icon" viewBox="0 0 448 512" aria-hidden="true" focusable="false"><path d="M0 96C0 78.3 14.3 64 32 64l384 0c17.7 0 32 14.3 32 32s-14.3 32-32 32L32 128C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32l384 0c17.7 0 32 14.3 32 32s-14.3 32-32 32L32 288c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32L32 448c-17.7 0-32-14.3-32-32s14.3-32 32-32l384 0c17.7 0 32 14.3 32 32z"/></svg></button>
     <nav class="header-nav" id="navMenu">
         <button class="mobile-menu-close" aria-label="Close"><svg class="icon" viewBox="0 0 384 512" aria-hidden="true" focusable="false"><path d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"/></svg></button>
@@ -55,7 +55,7 @@
             </div>
         </div>
         <div class="jellyfish">
-            <img src="./assets/img/jellyfish.png" alt="Jellyfish">
+            <img src="./assets/img/jellyfish.png" alt="Jellyfish" width="800" height="1200">
         </div>
     </div>
 </section>
@@ -72,8 +72,8 @@
             <div class="accent-bar"></div>
         </div>
         <div class="showcase-crossfade" id="showcaseCrossfade">
-            <img src="./assets/img/aami-blueprint.jpg" alt="AAMI Blueprint" class="showcase-img showcase-blueprint">
-            <img src="./assets/img/aami-realistic.jpg" alt="AAMI Realistic" class="showcase-img showcase-real">
+            <img src="./assets/img/aami-blueprint.jpg" alt="AAMI Blueprint" class="showcase-img showcase-blueprint" width="1200" height="840" loading="lazy">
+            <img src="./assets/img/aami-realistic.jpg" alt="AAMI Realistic" class="showcase-img showcase-real" width="1200" height="900" loading="lazy">
         </div>
     </div>
 </section>
@@ -284,7 +284,7 @@
 <footer class="site-footer">
     <div class="footer-inner">
         <div class="footer-brand">
-            <img src="./assets/img/bpmspace_weblogo.png" alt="BPMspace">
+            <img src="./assets/img/bpmspace_weblogo.png" alt="BPMspace" width="72" height="72" loading="lazy">
             <p><span class="lang-en">Autonomous Maritime Intelligence</span><span class="lang-de">Autonome Maritime Intelligenz</span></p>
         </div>
         <details class="legal-details">


### PR DESCRIPTION
## Phase 2 — performance (issue #3)

Lighthouse could not be run in the dev environment (no headless Chrome), so the data-driven subset selection from the plan was reduced to the unconditionally-safe items:

- explicit `width`/`height` on every `<img>` (jellyfish 800×1200, showcase blueprint 1200×840, showcase realistic 1200×900, logo 72×72) — reserves layout space, avoids CLS
- `loading="lazy"` on the two showcase images and the footer logo (below the fold); the hero jellyfish is **not** lazy-loaded (initial viewport)
- no visual change

### Still open / owner action
- Run Lighthouse (`npx lighthouse https://www.bpmspace.com --preset=desktop` ×5, mobile ×5) before/after to confirm Performance ≥ baseline, no CLS regression, LCP ≤ +100 ms.
- `assets/img/jellyfish.png` is **533 KB** — the single biggest asset and the obvious next win. Converting it (and the two ~170–184 KB showcase JPEGs) to WebP/AVIF would cut ~60–80% off image bytes. This is a binary-asset change, left as a separate proposal per the spec — say the word and I'll do it.

Refs #3